### PR TITLE
Block mouse movement while drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ I am a fan of practicing writing those crazy difficult Japanese Kanji. As a Japa
 - [x] Visualize touch input position on GUI
 - [ ] Integrate with TensorFlow (threading)
 
+## User guide
+
+- The application can only be focused using `Alt+Tab`.
+- Press `F3` to enter touchpad writing mode. __CAUTION__ Your mouse movement will be locked while you are in touchpad writing mode.
+- Press `ESC` to exit touchpad writing mode.
+- Press `c` to clear the canvas.
+- The application currently can only be resized consistently with `Windows Key` + `Arrow Keys` as the application does not handle clicking properly.
+
 ## Current progress
 
 - We have been able to get the absolute touchpad input positions and visualize them on a UI window.

--- a/docs/win32/learnwin32/user-input/accelerator-tables.md
+++ b/docs/win32/learnwin32/user-input/accelerator-tables.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/accelerator-tables -->

--- a/docs/win32/learnwin32/user-input/keyboard-input.md
+++ b/docs/win32/learnwin32/user-input/keyboard-input.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/keyboard-input -->

--- a/docs/win32/learnwin32/user-input/mouse-clicks.md
+++ b/docs/win32/learnwin32/user-input/mouse-clicks.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/mouse-clicks -->

--- a/docs/win32/learnwin32/user-input/mouse-input.md
+++ b/docs/win32/learnwin32/user-input/mouse-input.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/mouse-input -->

--- a/docs/win32/learnwin32/user-input/mouse-input.md
+++ b/docs/win32/learnwin32/user-input/mouse-input.md
@@ -1,1 +1,21 @@
 <!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/mouse-input -->
+
+# Mouse Input
+
+Windows supports mice with up to five buttons, left, middle, and right, plus two additional buttons called `XBUTTON1` and `XBUTTON2`.
+
+![](https://docs.microsoft.com/en-us/windows/win32/learnwin32/images/mouse.png)
+
+Most mice for Windows have at least the left and right buttons. The left mouse button is used for pointing, selecting, dragging, and so forth. The right mouse button typically displays a context menu. Some mice have a scroll wheel located between the left and right buttons. Depending on the mouse, the scroll wheel might also be clickable, making it the middle button.
+
+The `XBUTTON1` and `XBUTTON2` buttons are often located on the sides of the mouse near the base. These extra buttons are not present on all mice. If present, the `XBUTTON1` and `XBUTTON2` buttons are often mapped to an application function, such as forward and backward navigation in a Web browser.
+
+Left-handed users often find it more comfortable to swap the functions of the left and right buttons - using the right button as the pointer, and the left button to show the context menu. For this reason, the Windows help documentation uses the terms _primary button_ and _secondary button_, which refer to logical function rather than physical placement. In the default (right-handed) setting, the left button is the primary button and the right is the secondary button. However, the terms _right click_ and _left click_ refer to logical actions. _Right clicking_ means clicking the primary button, whether that button is physically on the right or left side of the mouse.
+
+Regardless of how the user configures the mouse, Windows automatically translates mouse messages so they are consistent. The user can swap the primary and secondary buttons in the middle of using your program, and it will not affect how your program behaves.
+
+MSDN documentation uses the terms _right button_ and _left button_ to mean _primary_ and _secondary_ button. This terminology is consistent with the names of the window messages for mouse input. Just remember that the physical left and right buttons might be swapped.
+
+## Next
+
+[Responding to Mouse Clicks](./mouse-clicks.md)

--- a/docs/win32/learnwin32/user-input/mouse-movement.md
+++ b/docs/win32/learnwin32/user-input/mouse-movement.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/mouse-movement -->

--- a/docs/win32/learnwin32/user-input/other-mouse-operations.md
+++ b/docs/win32/learnwin32/user-input/other-mouse-operations.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/other-mouse-operations -->

--- a/docs/win32/learnwin32/user-input/readme.md
+++ b/docs/win32/learnwin32/user-input/readme.md
@@ -1,0 +1,16 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/module-4--user-input -->
+
+# Module 4. User Input
+
+Previous modules have explored creating a window, handling window messages, and basic drawing with 2D graphics. In this module, we look at mouse and keyboard input. By the end of this module, you will be able to write a simple drawing program that uses the mouse and keyboard.
+
+## In this section
+
+- [Mouse Input](./mouse-input.md)
+- [Responding to Mouse Clicks](./mouse-clicks.md)
+- [Mouse Movement](./mouse-movement.md)
+- [Miscellaneous Move Operations](./other-mouse-operations.md)
+- [Keyboard Input](./keyboard-input.md)
+- [Accelerator Tables](./accelerator-tables.md)
+- [Setting the Cursor Image](./setting-the-cursor-image.md)
+- [User Input: Extended Example](./user-input-extended-example.md)

--- a/docs/win32/learnwin32/user-input/setting-the-cursor-image.md
+++ b/docs/win32/learnwin32/user-input/setting-the-cursor-image.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/setting-the-cursor-image -->

--- a/docs/win32/learnwin32/user-input/user-input-extended-example.md
+++ b/docs/win32/learnwin32/user-input/user-input-extended-example.md
@@ -1,0 +1,1 @@
+<!-- https://docs.microsoft.com/en-us/windows/win32/learnwin32/user-input--extended-example -->

--- a/touchpad/src/main.cc
+++ b/touchpad/src/main.cc
@@ -831,7 +831,7 @@ int CALLBACK wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
   ShowWindow(hwnd, nCmdShow);
   UpdateWindow(hwnd);
 
-  BOOL block_input_retval;
+  // BOOL block_input_retval;
   MSG msg;
   while (GetMessage(&msg, NULL, 0, 0))
   {
@@ -840,29 +840,35 @@ int CALLBACK wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance
 
     if (g_call_block_input_flag != 0)
     {
-      block_input_retval = BlockInput(TRUE);
-      printf(FG_YELLOW);
-      printf("BlockInput(TRUE): %d\n", block_input_retval);
-      printf(RESET_COLOR);
-      g_call_block_input_flag = 0;
+      // TODO find a way to call BlockInput without the need of UAC permission as KeyFreeze
+      // block_input_retval = BlockInput(TRUE);
+      // printf(FG_YELLOW);
+      // printf("BlockInput(TRUE): %d\n", block_input_retval);
+      // printf(RESET_COLOR);
+      // if (block_input_retval == 0)
+      //{
+      //  mGetLastError();
+      //}
 
-      if (block_input_retval == 0)
-      {
-        mGetLastError();
-      }
+      RECT lockCursorRect = {0, 0, 1, 1};
+      ClipCursor(&lockCursorRect);
+
+      g_call_block_input_flag = 0;
     }
     else if (g_call_unblock_input_flag != 0)
     {
-      block_input_retval = BlockInput(FALSE);
-      printf(FG_YELLOW);
-      printf("BlockInput(FALSE): %d\n", block_input_retval);
-      printf(RESET_COLOR);
-      g_call_unblock_input_flag = 0;
+      // TODO find a way to detect keyboard state while blocking input
+      // block_input_retval = BlockInput(FALSE);
+      // printf(FG_YELLOW);
+      // printf("BlockInput(FALSE): %d\n", block_input_retval);
+      // printf(RESET_COLOR);
+      // if (block_input_retval == 0)
+      //{
+      //  mGetLastError();
+      //}
 
-      if (block_input_retval == 0)
-      {
-        mGetLastError();
-      }
+      ClipCursor(NULL);
+      g_call_unblock_input_flag = 0;
     }
   }
 

--- a/touchpad/src/utils.cc
+++ b/touchpad/src/utils.cc
@@ -26,30 +26,35 @@ void mGetLastError()
 
 void print_HidP_errors(NTSTATUS hidpReturnCode, const char* filePath, int lineNumber)
 {
+  printf(FG_RED);
+
   if (hidpReturnCode == HIDP_STATUS_INVALID_REPORT_LENGTH)
   {
-    std::cout << FG_RED << "The report length is not valid. HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("The report length is not valid. HidP function failed at ");
   }
   else if (hidpReturnCode == HIDP_STATUS_INVALID_REPORT_TYPE)
   {
-    std::cout << FG_RED << "The specified report type is not valid. HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("The specified report type is not valid. HidP function failed at ");
   }
   else if (hidpReturnCode == HIDP_STATUS_INCOMPATIBLE_REPORT_ID)
   {
-    std::cout << FG_RED << "The collection contains a value on the specified usage page in a report of the specified type, but there are no such usages in the specified report. HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("The collection contains a value on the specified usage page in a report of the specified type, but there are no such usages in the specified report. HidP function failed at ");
   }
   else if (hidpReturnCode == HIDP_STATUS_INVALID_PREPARSED_DATA)
   {
-    std::cout << FG_RED << "The preparsed data is not valid. HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("The preparsed data is not valid. HidP function failed at ");
   }
   else if (hidpReturnCode == HIDP_STATUS_USAGE_NOT_FOUND)
   {
-    std::cout << FG_RED << "The collection does not contain a value on the specified usage page in any report of the specified report type. HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("The collection does not contain a value on the specified usage page in any report of the specified report type. HidP function failed at ");
   }
   else
   {
-    std::cout << FG_RED << "Unknown error code: " << hidpReturnCode << ". HidP function failed at " << filePath << ":" << lineNumber << RESET_COLOR << std::endl;
+    printf("Unknown error code: %d. HidP function failed at ", hidpReturnCode);
   }
+
+  printf("%s:%d\n", filePath, lineNumber);
+  printf(RESET_COLOR);
 }
 
 int FindInputDeviceInList(HID_DEVICE_INFO_LIST* hidInfoList, TCHAR* deviceName, const unsigned int cbDeviceName, PHIDP_PREPARSED_DATA preparsedData, const UINT cbPreparsedData, unsigned int* foundHidIndex)

--- a/touchpad/src/utils.cc
+++ b/touchpad/src/utils.cc
@@ -17,8 +17,10 @@ void mGetLastError()
   LPWSTR messageBuffer = NULL;
   size_t size          = FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
 
-  std::cout << FG_RED << "Error code: " << errorCode << std::endl;
-  std::wcout << messageBuffer << RESET_COLOR << std::endl;
+  printf(FG_RED);
+  printf("Error Code: %d\n", errorCode);
+  wprintf(L"%s\n", messageBuffer);
+  printf(RESET_COLOR);
   // TODO check to see if we don't free the messageBuffer pointer, will it lead to memory leaking?
 }
 


### PR DESCRIPTION
- User has to press `F3` to enter writing mode otherwise nothing will be drawn on screen.
- User can press `ESC` to escape the drawing mode.
- User can press `C` to clear the drawing canvas.
- User can press `Q` to quit the application as mouse interaction with the application is broken because of the transparency layered window.
- Block mouse movement with `ClipCursor` API call.

These are some problems I would hope to tackle in the future:

- `BlockInput` API call requires `UAC` permission and it will block all key input events (keyboard and mouse click) but not mouse movement.
- A program called `KeyFreeze` was able to run without `UAC` but it was able to block keyboard and mouse input with the `BlockInput` call. In addition, `KeyFreeze` was able to detect the keyboard state after `BlockInput` has been called to unblock the keyboard and mouse.